### PR TITLE
Feat/strategy

### DIFF
--- a/flavor/serve/inference/data_models/functional/aicoco_data_model.py
+++ b/flavor/serve/inference/data_models/functional/aicoco_data_model.py
@@ -1,9 +1,13 @@
 """
 This module defines a set of Pydantic models for handling AICOCO format.
 """
-from typing import List, Literal, Optional, Sequence
+from typing import List, Literal, Optional, Sequence, TypedDict, Union
 
 from pydantic import BaseModel
+
+# ==============================
+# Annotation Related Models
+# ==============================
 
 
 class AiAnnotation(BaseModel, extra="allow"):
@@ -13,6 +17,11 @@ class AiAnnotation(BaseModel, extra="allow"):
     object_id: str
     bbox: Optional[Sequence[Sequence[int]]]
     segmentation: Optional[List[Sequence[int]]]
+
+
+# ==============================
+# Category and Regression Definitions
+# ==============================
 
 
 class AiCategory(BaseModel, extra="allow"):
@@ -32,6 +41,11 @@ class AiRegressionItem(BaseModel, extra="forbid"):
     value: float
 
 
+# ==============================
+# Object and Metadata Models
+# ==============================
+
+
 class AiObject(BaseModel, extra="allow"):
     id: str
     category_ids: Optional[List[str]]
@@ -42,10 +56,21 @@ class AiMeta(BaseModel, extra="allow"):
     category_ids: Optional[List[str]]
     regressions: Optional[List[AiRegressionItem]]
 
+
+class AiTableMeta(BaseModel, extra="allow"):
+    window_size: int
+
+
 class AiHybridMeta(BaseModel, extra="allow"):
     category_ids: Optional[List[str]]
     regressions: Optional[List[AiRegressionItem]]
     table_ids: Optional[List[str]]
+
+
+# ==============================
+# Image Related Models
+# ==============================
+
 
 class AiImage(BaseModel, extra="allow"):
     file_name: str
@@ -55,13 +80,9 @@ class AiImage(BaseModel, extra="allow"):
     regressions: Optional[List[AiRegressionItem]]
 
 
-class AiCOCOImageFormat(BaseModel, extra="forbid"):
-    images: Sequence[AiImage]
-    annotations: Sequence[AiAnnotation]
-    categories: Sequence[AiCategory]
-    regressions: Sequence[AiRegression]
-    objects: Sequence[AiObject]
-    meta: AiMeta
+# ==============================
+# Tabular Related Models
+# ==============================
 
 
 class AiTable(BaseModel, extra="allow"):
@@ -77,8 +98,35 @@ class AiRecord(BaseModel, extra="allow"):
     regressions: Optional[Sequence[AiRegressionItem]]
 
 
-class AiTableMeta(BaseModel, extra="allow"):
-    window_size: int
+# ==============================
+# Intermediate Models
+# ==============================
+
+
+class AiCOCORef(BaseModel):
+    images: List[AiImage]
+    categories: List[AiCategory]
+    regressions: List[AiRegression]
+    meta: Union[AiMeta, AiTableMeta, AiHybridMeta]
+
+
+class AiCOCOAnnotObj(TypedDict):
+    annotations: List[AiAnnotation]
+    objects: List[AiObject]
+
+
+# ==============================
+# Full Format Models
+# ==============================
+
+
+class AiCOCOImageFormat(BaseModel, extra="forbid"):
+    images: Sequence[AiImage]
+    annotations: Sequence[AiAnnotation]
+    categories: Sequence[AiCategory]
+    regressions: Sequence[AiRegression]
+    objects: Sequence[AiObject]
+    meta: AiMeta
 
 
 class AiCOCOTabularFormat(BaseModel, extra="forbid"):


### PR DESCRIPTION
### **Overview**

This MR refactors the AiCOCO data models and output strategy classes to improve structure, consistency, and reusability.

---

### **Key Changes**

- Introduced `AiCOCORef` (a Pydantic `BaseModel`) to replace multiple `TypedDict` variants.
- Grouped and cleaned up model definitions in `aicoco_data_model.py` for clarity (e.g., annotation, image, table, hybrid sections).
- Updated all output strategies to use unified `AiCOCORef` and return structured formats like `AiCOCOImageFormat`, `AiCOCOTabularFormat`, and `AiCOCOHybridFormat`.
- Added `BaseAiCOCOHybridOutputStrategy` to reduce duplicate code in hybrid strategies.
- Replaced `.dict` and manual dict merging with `.model_dump()` and `.model_validate()` for better validation and consistency.